### PR TITLE
now streaming tweets directly into mongo DB

### DIFF
--- a/get_tweets.py
+++ b/get_tweets.py
@@ -2,6 +2,12 @@
 from config import * # configuration
 import tweepy as twpy
 import requests
+from pymongo import MongoClient
+
+# MongoDB connection
+client = MongoClient('mongodb://3.22.27.22:27017')
+db = client.final_proj
+collection = db.tweets
 
 # Authenticate against Twitter:
 auth = twpy.OAuthHandler(twitter_app_key, twitter_app_secret)
@@ -21,9 +27,16 @@ results
 ## STREAMING -----
 # Set up stream listener
 class StreamListener(twpy.StreamListener):
+
     def on_status(self, status):
         # STATUS IS THE JSON OBJECT - INSERT THAT INTO THE DB?
         print(status)
+        collection.update(
+            {'id': status._json['id']},
+            {'$set': status._json},
+            upsert=True
+        )
+
     def on_error(self, status_code):
         if status_code == 420:
             return False


### PR DESCRIPTION
added functionality that updates the mongo DB with each tweet as it gets streamed in. Tested in debug mode on a few. Works well, but we should probably limit the number of fields we ingest